### PR TITLE
CSE-161 Exception Handler

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::API
+  include ExceptionHandler
   include ActionController::Serialization
   # need to include this one as it does not come with API
   include ActionController::MimeResponds

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -1,0 +1,84 @@
+module ExceptionHandler
+  extend ActiveSupport::Concern
+
+  ERROR_MAP = {
+    ActiveRecord::RecordNotFound => {
+      method: :record_not_found,
+      status: :not_found
+    },
+    ActionController::ParameterMissing => {
+      method: :parameter_missing,
+      status: :unprocessable_entity
+    },
+    ActiveRecord::RecordInvalid => {
+      method: :record_invalid,
+      status: :unprocessable_entity
+    },
+    AbstractController::ActionNotFound => {
+      method: :record_not_found,
+      status: :not_found
+    },
+    ActionController::RoutingError => {
+      method: :route_not_found,
+      status: :not_found
+    }
+  }.freeze
+
+  included do
+    rescue_from StandardError do |e|
+      logger.error(e.message)
+      handle_error(e)
+    end
+  end
+
+  private
+
+  def handle_error(e)
+    if ERROR_MAP.keys.include? e.class
+      handler = ERROR_MAP[e.class]
+      body = send(handler[:method], e)
+      status = handler[:status]
+    else
+      body = {
+        message: e.message
+      }
+      status = e.status
+    end
+
+    render json: body, status: status
+  end
+
+  # Define the return bodies here, per error type
+
+  def route_not_found(e)
+    {
+      message: "Route not found",
+      details: e.message
+    }
+  end
+
+  def record_not_found(e)
+    {
+      message: "Not found",
+      details: e.message
+    }
+  end
+
+  def parameter_missing(e)
+    {
+      message: "Parameter missing",
+      details: e.message,
+      parameter: e.param
+    }
+  end
+
+  def record_invalid(e)
+    {
+      model: e.record.class.name,
+      attributes: e.record.errors.messages.keys,
+      message: "Invalid record",
+      details: e.record.errors.messages
+    }
+  end
+end
+


### PR DESCRIPTION
JSON response from RestAPI has stack traces that don't need
to be shown to the user.
This happens even when config.consider_all_requests_local = false
which disables full error reports.